### PR TITLE
fix: export rxy_macro

### DIFF
--- a/examples/game_ui_challenges/components/mod.rs
+++ b/examples/game_ui_challenges/components/mod.rs
@@ -1,6 +1,5 @@
 use bevy::prelude::Color;
 use rxy_bevy::event::{ElementEventId, ElementEventIds};
-use rxy_macro::TypedStyle;
 
 mod checkbox;
 mod select;


### PR DESCRIPTION
The rxy_macro crate have been used at `examples/game_ui_challenges/components/mod.rs:3`, but it has not export from the main crate.

Add export at this PR.